### PR TITLE
pynYNAB no longer requires dev version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -200,7 +200,7 @@ pynab==0.6.8
 # License: MIT
 # Homepage: https://github.com/rienafairefr/nYNABapi
 # Author: rienafairefr
-pynYNAB===dev
+pynYNAB
 
 # pyparsing
 # License: MIT License

--- a/src/main.py
+++ b/src/main.py
@@ -4,7 +4,7 @@ import csv
 import datetime
 from progress.bar import Bar
 
-from pynYNAB.Client import clientfromargs
+from pynYNAB.ClientFactory import clientfromargs
 from pynYNAB.schema.budget import Transaction, Payee
 
 from src.database import store_categories


### PR DESCRIPTION
When running `pip install -r requirements.txt` it fails on `pynYNAB===dev`. 
I removed `===dev`, and updated `main.py`. The import statement failed
with the pip installed version of `pynYNAB`.