### PR TITLE
Adds basic CI with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.5-dev" # 3.5 development branch
+  - "3.6"
+  - "3.6-dev" # 3.6 development branch
+  - "3.7-dev" # 3.7 development branch
+  - "nightly" # currently points to 3.7-dev
+# command to install dependencies
+install: "pip install -r requirements.txt"
+# command to run tests
+script: pytest


### PR DESCRIPTION
Runs `pytest` for a range of different python versions. 

Check the output of the tests at https://travis-ci.org/KPLauritzen/Nordea-to-YNAB/builds/252295437, where Python 2.7 passes and the other versions fail.

They fail at the `install pip ...` because of packages that are specific to python2.7.
```
Collecting functools32==3.2.3.post2 (from -r requirements.txt (line 81))
  Downloading functools32-3.2.3-2.zip
    This backport is for Python 2.7 only.
```

I can't see where functools is used in the package? Can I just remove it?